### PR TITLE
Fixing package.json to not update to angular 1.6

### DIFF
--- a/package.json
+++ b/package.json
@@ -11,7 +11,7 @@
   "license": "MIT",
   "repository": "https://github.com/toddmotto/ultimate-angular-master-seed",
   "dependencies": {
-    "angular": "^1.5.8",
+    "angular": "~1.5.8",
     "angular-loading-bar": "^0.9.0",
     "angular-messages": "^1.5.8",
     "angular-ui-router": "1.0.0-beta.2",


### PR DESCRIPTION
The package.json file specifies:
`"dependencies": {
    "angular": "^1.5.8"}`
however, this will allow NPM to grab angular 1.6, 1.7, etc. By changing the '^' to '~', we can tell NPM to only use versions of angular 1.5.* at or after 1.5.8 (it would also be acceptable to lock the version to 1.5.8 if desired)